### PR TITLE
Untested PR: fixes accordion SCSS for Civi > 5.69

### DIFF
--- a/scss/civicrm/common/_accordions.scss
+++ b/scss/civicrm/common/_accordions.scss
@@ -2,25 +2,16 @@
   border-radius: 0 !important;
 }
 
-.crm-accordion-header {
+.crm-accordion-header,
+.crm-accordion-bold > summary {
   @include accordion-header;
 
   &:not(.crm-master-accordion-header) {
     border-bottom: 1px solid $crm-grayblue-dark;
     font-size: $font-size-base !important;
     font-weight: $crm-font-weight-h3;
-  }
+    padding: 16px 20px !important;
 
-  &.crm-master-accordion-header {
-    background: $brand-primary !important;
-    border-radius: $border-radius-base $border-radius-base 0 0 !important;
-    color: $crm-white !important;
-    font-size: $font-size-h2;
-    font-weight: $crm-font-weight-h3 !important;
-
-    &::before {
-      color: $crm-white;
-    }
   }
 
   .crm-close-accordion {
@@ -39,6 +30,21 @@
       color: $crm-white;
       opacity: 0.8;
     }
+  }
+}
+
+.crm-master-accordion-header,
+.crm-accordion-light > summary {
+  background: $brand-primary !important;
+  border-radius: $border-radius-base $border-radius-base 0 0 !important;
+  color: $crm-white !important;
+  font-size: $font-size-h2;
+  font-weight: $crm-font-weight-h3 !important;
+  padding: 16px 20px !important;
+
+
+  &::before {
+    color: $crm-white;
   }
 }
 
@@ -67,11 +73,47 @@
   }
 }
 
-.crm-master-accordion-header + .crm-accordion-body {
+// repeats above pattern for new markup
+
+details {
+  border-radius: 0;
+  margin-bottom: 0;
+
+  &:[open] {
+    summary {
+      &::before {
+        content: '\f107';
+      }
+    }
+  }
+
+  &:not([open]) {
+    summary {
+      &::before {
+        content: '\f105';
+      }
+    }
+  }
+
+  &.crm-accordion-light:not([open]) {
+    summary {
+      border-radius: $border-radius-base !important;
+    }
+  }
+}
+
+// Remove padding for accordions in accordions
+details details {
+  padding: 0;
+}
+
+.crm-master-accordion-header + .crm-accordion-body,
+.crm-accordion-light > .crm-accordion-body {
   border-radius: 0 0 $border-radius-base $border-radius-base !important;
 }
 
-.crm-accordion-header:not(.crm-master-accordion-header) + .crm-accordion-body {
+.crm-accordion-header:not(.crm-master-accordion-header) + .crm-accordion-body,
+.crm-accordion-bold > .crm-accordion-body {
   box-shadow: $crm-box-shadow-inset;
   padding: 15px !important;
 


### PR DESCRIPTION
Closing a major accessibility gap, accordion markup across Civi has been upgraded between 5.69 + 5.72 to make them keyboard and screen-reader friendly.

This PR adds the new changes as described in https://lab.civicrm.org/dev/user-interface/-/wikis/DINO:-Notify-themes-+-New-theme/changes-in-5.69, in order to preserve Shoreditch styles on the new accordions.

However, I've been unable to fully install Shoreditch to compile these changes into css locally so can't test this PR. However I have tested a largely similar PR in The Island theme: https://lab.civicrm.org/extensions/theisland/-/merge_requests/9.

## Overview
_A brief description of the pull request. Try to keep it non-technical._

## Before
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

## After
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

## Technical Details
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

## Backstop JS Report
_Attaching Backstop JS test report is must for every Pull Request. Run BackstopJS tests from https://github.com/compucorp/backstopjs-config/actions/workflows/backstop.yml, and attach a link to the workflow run_
## Comments
_Anything else you would like the reviewer to note_
